### PR TITLE
Refresh on Diagram Definition change. Links to the GitHub project for Grafana.net

### DIFF
--- a/dist/diagramEditor.html
+++ b/dist/diagramEditor.html
@@ -3,4 +3,4 @@
 	href="http://knsv.github.io/mermaid/">Mermaid syntax</a>.)
 </span>
 <textarea class="gf-form-input" ng-model="ctrl.panel.content" rows="20"
-	style="width: 95%" ng-change="ctrl.render()" ng-model-onblur></textarea>
+	style="width: 95%" ng-change="ctrl.refresh()" ng-model-onblur></textarea>

--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -10,6 +10,10 @@
       "url": "https://github.com/jdbranham"
     },
     "keywords": ["diagram", "panel"],
+    "links": [
+      {"name": "Project site", "url": "https://github.com/jdbranham/grafana-diagram"},
+      {"name": "Apache License", "url": "https://github.com/jdbranham/grafana-diagram/blob/master/LICENSE"}
+    ],
     "version": "1.0.2",
     "updated": "2016-09-29"
   },

--- a/plugin.json
+++ b/plugin.json
@@ -10,6 +10,10 @@
       "url": "https://github.com/jdbranham"
     },
     "keywords": ["diagram", "panel"],
+    "links": [
+      {"name": "Project site", "url": "https://github.com/jdbranham/grafana-diagram"},
+      {"name": "Apache License", "url": "https://github.com/jdbranham/grafana-diagram/blob/master/LICENSE"}
+    ],
     "version": "1.0.2",
     "updated": "2016-09-29"
   },

--- a/src/diagramEditor.html
+++ b/src/diagramEditor.html
@@ -3,4 +3,4 @@
 	href="http://knsv.github.io/mermaid/">Mermaid syntax</a>.)
 </span>
 <textarea class="gf-form-input" ng-model="ctrl.panel.content" rows="20"
-	style="width: 95%" ng-change="ctrl.render()" ng-model-onblur></textarea>
+	style="width: 95%" ng-change="ctrl.refresh()" ng-model-onblur></textarea>


### PR DESCRIPTION
Two changes:

1. Refresh on change for the Diagram Definition field instead of just re-rendering. This means that the diagram gets updated after a change if you just click outside the field rather than having to click the refresh button.
![mermaid](https://cloud.githubusercontent.com/assets/434655/18986408/ed026b98-86fc-11e6-8a7e-3c458a1ea1bc.gif)


2. Adds links for the GitHub repo in the plugin.json that will show up as links on [Grafana.net](https://grafana.net/plugins/jdbranham-diagram-panel).

