### PR TITLE
Fixed async call of external URL to retrieve graph data.

### DIFF
--- a/src/diagramControl.js
+++ b/src/diagramControl.js
@@ -124,6 +124,7 @@ class DiagramCtrl extends MetricsPanelCtrl {
     this.events.on('init-edit-mode', this.onInitEditMode.bind(this));
     this.events.on('data-received', this.onDataReceived.bind(this));
     this.events.on('data-snapshot-load', this.onDataReceived.bind(this));
+    //this.panel.content = 'abc';
     this.unitFormats = kbn.getUnitFormats();
     this.initializeMermaid();
   }
@@ -157,9 +158,9 @@ class DiagramCtrl extends MetricsPanelCtrl {
 
     var data = {};
     this.setValues(data);
-    this.updateDiagram(data);
     this.svgData = data;
-    this.render();
+    this.updateDiagram(data);
+    //this.render();
   }
 
   replaceMetricCharacters(metricName) {
@@ -315,11 +316,13 @@ class DiagramCtrl extends MetricsPanelCtrl {
           //the response must have text/plain content-type
           // console.info(response.data);
           updateDiagram_cont(_this, response.data);
+          _this.render();
         }, function errorCallback(response) {
           console.warn('error', response);
         })
       } else {
         updateDiagram_cont(this, this.panel.content);
+        this.render();
       }
     }
   } // End updateDiagram()

--- a/src/diagramControl.js
+++ b/src/diagramControl.js
@@ -314,7 +314,7 @@ class DiagramCtrl extends MetricsPanelCtrl {
         }).then(function successCallback(response) {
           //the response must have text/plain content-type
           // console.info(response.data);
-          updateDiagram_cont.call(_this, response.data);
+          updateDiagram_cont(_this, response.data);
         }, function errorCallback(response) {
           console.warn('error', response);
         })


### PR DESCRIPTION
I had the problem, that the graph didn't load if I tried to load it from a URL.

Exception:

angular.js:14700 TypeError: _this.substituteHashPrefixedNotation is not a function
    at DiagramCtrl.updateDiagram_cont (diagramControl.js:292)
    at successCallback (diagramControl.js:317)
    at u (angular.js:17051)
    at angular.js:17095
    at h.$digest (angular.js:18233)
    at h.$apply (angular.js:18531)
    at angular.js:18832
    at i (angular.js:6362)
    at angular.js:6642 "Possibly unhandled rejection: {}"

The fix was simple, please see the diff.