### PR TITLE
Update composite edit image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The composite name is evaluated in the Diagram definition.
 
 For example, combining two series "A-series" and "B-series" into a single composite named "xyz", the following can be used:
 
-![Composite Editor](https://raw.githubusercontent.com/jdbranham/grafana-diagram/master/src/img/composite-edit-tab.png?raw=true)
+![Composite Editor](https://raw.githubusercontent.com/jdbranham/grafana-diagram/master/src/img/composite-editor-tab.png?raw=true)
 
 With series specific overrides for these two series:
 


### PR DESCRIPTION
Link to the composite edit image is broken - this PR should address that documentation issue.

<img width="896" alt="Screenshot 2020-06-24 10 23 18" src="https://user-images.githubusercontent.com/2196244/85574397-bb7edf80-b604-11ea-9865-939c4448d66d.png">