### PR TITLE
Change link to Mermaid docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ In the diagram the value of the matching series will be mapped to text:
 
 
 Special thanks to the Mermaid contributors -  
-https://github.com/knsv/mermaid/graphs/contributors  
-https://knsv.github.io/mermaid/  
+https://github.com/mermaid-js/mermaid/graphs/contributors  
+https://mermaid-js.github.io/  
 
 and the D3 contributors -  
 https://github.com/d3/d3/graphs/contributors  

--- a/src/module.ts
+++ b/src/module.ts
@@ -190,7 +190,7 @@ const createPanelPlugin = () => {
         .addTextInput({
           name: 'Diagram definition',
           path: 'content',
-          description: `This area uses Mermaid syntax - http://knsv.github.io/mermaid/`,
+          description: `This area uses Mermaid syntax - https://mermaid-js.github.io/`,
           defaultValue: defaults.content,
           settings: {
             rows: 10,


### PR DESCRIPTION
Mermaid repo & site moved from https://knsv.github.io/mermaid/ (Error 404) to https://mermaid-js.github.io/