### PR TITLE
This turns the whole background shape the same color as indicator for FlowChart diagram nodes

### DIFF
--- a/src/config/diagramDefaults.ts
+++ b/src/config/diagramDefaults.ts
@@ -7,6 +7,7 @@ export const defaultFlowChartConfig: FlowchartDiagramConfig & { useMaxWidth: boo
   curve: 'linear',
   htmlLabels: true,
   useMaxWidth: true,
+  padding: 40
 };
 
 export const defaultMermaidOptions: MermaidConfig = {

--- a/src/diagramStyleFormatter.ts
+++ b/src/diagramStyleFormatter.ts
@@ -2,6 +2,8 @@ function diagramStyleFormatter(customStyle: string, diagramId: string) {
   return `
 	#${diagramId} .badge, #${diagramId} .label {
 		text-shadow: none;
+		line-height: unset;
+		font-size: 0.75rem;
 	}
 
 	#${diagramId} foreignObject {

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -55,6 +55,16 @@ const selectTextElementContainingAlias = (container: HTMLElement, alias: string)
     });
 };
 
+const fetchParentsUntilShapeElementFound = (element: HTMLElement, selector: string): HTMLElement | null => {  
+  if (element.matches(selector)) {
+    return element;
+  }
+  if (element.parentElement) {
+    return fetchParentsUntilShapeElementFound(element.parentElement, selector);
+  }
+  return null;
+}
+
 const resizeGrouping = (element: Selection<any, any, any, any> | null | undefined, nodeSize: NodeSizeOptions) => {
   if (!element) {
     return;
@@ -114,6 +124,7 @@ const styleFlowChartEdgeLabel = (
   useBackground: boolean,
   nodeSize: NodeSizeOptions
 ) => {
+  const parentShapeElement = fetchParentsUntilShapeElementFound(targetElement.node(), '.node.flowchart-label');
   const edgeParent = select(targetElement.node().parentNode);
   edgeParent.append('br');
   const v = edgeParent.append('span');
@@ -123,6 +134,7 @@ const styleFlowChartEdgeLabel = (
   if (indicator.color) {
     if (useBackground) {
       v.style('background-color', indicator.color);
+      parentShapeElement?.firstElementChild?.setAttribute('style', `fill: ${indicator.color}`);
     } else {
       v.style('color', indicator.color);
     }

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -123,8 +123,7 @@ const styleFlowChartEdgeLabel = (
   indicator: MetricIndicator,
   useBackground: boolean,
   nodeSize: NodeSizeOptions
-) => {
-  const parentShapeElement = fetchParentsUntilShapeElementFound(targetElement.node(), '.node.flowchart-label');
+) => {  
   const edgeParent = select(targetElement.node().parentNode);
   edgeParent.append('br');
   const v = edgeParent.append('span');
@@ -134,6 +133,7 @@ const styleFlowChartEdgeLabel = (
   if (indicator.color) {
     if (useBackground) {
       v.style('background-color', indicator.color);
+      const parentShapeElement = fetchParentsUntilShapeElementFound(targetElement.node(), '.node.flowchart-label');
       parentShapeElement?.firstElementChild?.setAttribute('style', `fill: ${indicator.color}`);
     } else {
       v.style('color', indicator.color);
@@ -307,7 +307,7 @@ export const updateDiagramStyle = (
   if (svg.parentElement && !options.maxWidth) {
     svg.parentElement.setAttribute('style', 'overflow-y: scroll');
   }
-  
+
   indicators.forEach((indicator) => {
     processDiagramSeriesModel(svg, indicator, options);
   });

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -12,7 +12,7 @@ type MetricIndicator = DisplayValue & {
 };
 
 const selectElementById = (container: HTMLElement, id: string): Selection<any, any, any, any> => {
-  return select(document.getElementById('#' + id));
+  return select(container.querySelector(`[data-id="${id}"]`));
 };
 
 const selectElementByEdgeLabel = (container: HTMLElement, id: string): Selection<any, any, any, any> => {

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -12,7 +12,7 @@ type MetricIndicator = DisplayValue & {
 };
 
 const selectElementById = (container: HTMLElement, id: string): Selection<any, any, any, any> => {
-  return select(container.querySelector('#' + id));
+  return select(document.getElementById('#' + id));
 };
 
 const selectElementByEdgeLabel = (container: HTMLElement, id: string): Selection<any, any, any, any> => {

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -304,6 +304,10 @@ export const updateDiagramStyle = (
     select(svg).style('max-width', '100%').style('max-height', '100%');
   }
 
+  if (svg.parentElement && !options.maxWidth) {
+    svg.parentElement.setAttribute('style', 'overflow-y: scroll');
+  }
+  
   indicators.forEach((indicator) => {
     processDiagramSeriesModel(svg, indicator, options);
   });


### PR DESCRIPTION
In previous (angular) version this seem to have been the default behaviour. 

Main change:

- For those who have set the option 
"Use shape background for metric indicator" to `true` and only affects Flow Charts

Additional changes:
- Adding some padding to flow chart nodes
- Reseting label text size and line-height to avoid text nodes sticking out of the box
- Added scrolling to those flowchart diagrams that have no `maxWidth` enabled so that they can overflow and still be used by scrolling up and down
- Fixed element selection by id if alias contains characters not allowed for id. It was erroring out with something like ```SyntaxError: Failed to execute 'querySelector' on 'Element': '#current_%' is not a valid selector.```

**Before:**
<img width="111" alt="SCR-20240222-lgga" src="https://github.com/jdbranham/grafana-diagram/assets/580672/fcdaa546-780c-4317-a156-4d744dca1f16">

**After:**
<img width="118" alt="SCR-20240222-lgaq" src="https://github.com/jdbranham/grafana-diagram/assets/580672/bfd64a5a-4626-48ee-9d5f-6430ce2c549b">
