### PR TITLE
Fix data binding on sequence diagrams and the table-legend header (Grafana 13); add legend options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Data now binds onto **sequence diagrams**. Matching a series to an actor or message no longer crashes the panel (`TypeError: ... reading 'getBBox'`) and no longer requires a threshold color to display the value.
 - Concurrent mermaid renders (on mount and on data refresh) could corrupt the diagram and attach a value to the wrong element. Each render now uses a unique id and only the most recent render is applied.
+- The **table legend header row** (column names) is no longer hidden on newer Grafana (verified on 13.1.0). Grafana's `VizLegend` only renders the header when the legend is sortable, so the legend now sets `isSortable`; the `Name`/stat column headers show again (they already did on 12.3.1).
 
 ### Changed
 - Sequence values are styled to match flowchart values: an actor's whole label is threshold-colored with the value centered beneath the name, while a message keeps its label above the arrow and places the value below it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project will be documented in this file.
 - Data now binds onto **sequence diagrams**. Matching a series to an actor or message no longer crashes the panel (`TypeError: ... reading 'getBBox'`) and no longer requires a threshold color to display the value.
 - Concurrent mermaid renders (on mount and on data refresh) could corrupt the diagram and attach a value to the wrong element. Each render now uses a unique id and only the most recent render is applied.
 - The **table legend header row** (column names) is no longer hidden on newer Grafana (verified on 13.1.0). Grafana's `VizLegend` only renders the header when the legend is sortable, so the legend now sets `isSortable`; the `Name`/stat column headers show again (they already did on 12.3.1).
+- **Connection labels** now take the threshold color across the whole label, not just the appended value: flowchart **edge** labels and sequence **message** labels are colored to match their value, like nodes and actors already do (both text-color and background modes).
 
 ### Changed
-- Sequence values are styled to match flowchart values: an actor's whole label is threshold-colored with the value centered beneath the name, while a message keeps its label above the arrow and places the value below it.
+- Sequence values are styled to match flowchart values: the value is placed with the label — centered beneath an actor's name, and below a message's label above the arrow.
 - Diagram element matching for text-based diagrams (e.g. sequence) is now **exact only**; the previous substring/partial matching was removed so values no longer bind to unintended elements.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- Data now binds onto **sequence diagrams**. Matching a series to an actor or message no longer crashes the panel (`TypeError: ... reading 'getBBox'`) and no longer requires a threshold color to display the value.
+- Concurrent mermaid renders (on mount and on data refresh) could corrupt the diagram and attach a value to the wrong element. Each render now uses a unique id and only the most recent render is applied.
+
+### Changed
+- Sequence values are styled to match flowchart values: an actor's whole label is threshold-colored with the value centered beneath the name, while a message keeps its label above the arrow and places the value below it.
+- Diagram element matching for text-based diagrams (e.g. sequence) is now **exact only**; the previous substring/partial matching was removed so values no longer bind to unintended elements.
+
+### Added
+- Legend panel options: **Placement** (Bottom/Right), **Mode** (Table/List) and **Values** (which stats to show as columns). Placement now updates live without a panel reload.
+- First unit tests for the data-binding/styling logic (`updateDiagramStyle`).
+
 ## v1.0.0
 
 Initial Release

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,15 @@
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
 
+const scaffoldConfig = require('./.config/jest.config');
+
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
-  ...require('./.config/jest.config'),
+  ...scaffoldConfig,
+  // d3's `main` entry is ESM-only; map it to the prebuilt UMD bundle so Jest can load it
+  // without transforming d3's many nested submodules (e.g. d3-array) missed by the scaffold.
+  moduleNameMapper: {
+    ...scaffoldConfig.moduleNameMapper,
+    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js',
+  },
 };

--- a/src/DiagramController.tsx
+++ b/src/DiagramController.tsx
@@ -227,6 +227,13 @@ export class DiagramPanelController extends React.Component<DiagramPanelControll
                   placement={this.props.options.legend.placement}
                   sortBy={this.props.options.legend.sortBy}
                   sortDesc={this.props.options.legend.sortDesc}
+                  // Newer Grafana (verified 13.1.0) renders the table-legend header row
+                  // `sr-only` (visually hidden) unless the legend is marked sortable; it
+                  // showed unconditionally on 12.3.1. `isSortable` postdates the pinned
+                  // @grafana/ui@9 types but is honored by the host Grafana's VizLegend at
+                  // runtime (sorting is already wired up via onToggleSort below).
+                  // @ts-expect-error isSortable is provided by the runtime @grafana/ui
+                  isSortable
                   onLabelClick={(item, event) => {}}
                   onToggleSort={this.onToggleSort}
                 />

--- a/src/DiagramController.tsx
+++ b/src/DiagramController.tsx
@@ -2,7 +2,7 @@ import { AbsoluteTimeRange, FieldConfigSource, GrafanaTheme2, InterpolateFunctio
 import { CustomScrollbar, VizLegendItem, stylesFactory, VizLegend } from '@grafana/ui';
 import { defaultMermaidOptions } from 'config/diagramDefaults';
 import DiagramErrorBoundary from 'DiagramErrorBoundary';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { merge } from 'lodash';
 import mermaid from 'mermaid';
 import React from 'react';
@@ -50,25 +50,13 @@ const getDiagramWithLegendStyles = stylesFactory(({ options }: DiagramPanelContr
 export class DiagramPanelController extends React.Component<DiagramPanelControllerProps, DiagramPanelControllerState> {
   diagramRef!: HTMLDivElement;
   bindFunctions?: Function;
+  renderToken = 0;
 
   constructor(props: DiagramPanelControllerProps) {
     super(props);
     this.onToggleSort = this.onToggleSort.bind(this);
     this.setDiagramRef = this.setDiagramRef.bind(this);
     this.renderCallback = this.renderCallback.bind(this);
-  }
-
-  static getDerivedStateFromProps(props: DiagramPanelControllerProps, state: DiagramPanelControllerState) {
-    const { diagramContainer, wrapper, legendContainer } = getDiagramWithLegendStyles(props);
-    if (!state) {
-      return {
-        diagramContainer,
-        wrapper,
-        legendContainer,
-      };
-    } else {
-      return null;
-    }
   }
 
   setDiagramRef(element: HTMLDivElement) {
@@ -143,24 +131,24 @@ export class DiagramPanelController extends React.Component<DiagramPanelControll
     mermaid.initialize(options);
   
     if (this.diagramRef) {
+      const token = ++this.renderToken;
       const diagramDefinition = await this.loadDiagramDefinition();
+      if (token !== this.renderToken) {
+        return;
+      }
       try {
-        const diagramId = `diagram-${this.props.id}`;
+        const diagramId = `diagram-${this.props.id}-${token}`;
         const interpolated = this.props.replaceVariables(this.contentProcessor(diagramDefinition));
   
-        try {
-          const { svg, bindFunctions } = await mermaidAPI.render(diagramId, interpolated);
-          this.diagramRef.innerHTML = svg;
-          if (bindFunctions) {
-            bindFunctions(this.diagramRef);
-          }
-        } catch (err) {
-          //console.log("Trying to apply the default theme: ", err);
-          const { svg, bindFunctions } = await mermaidAPI.render(diagramId, diagramDefinition);
-          this.diagramRef.innerHTML = svg;
-          if (bindFunctions) {
-            bindFunctions(this.diagramRef);
-          }
+        const rendered = await mermaidAPI
+          .render(diagramId, interpolated)
+          .catch(() => mermaidAPI.render(diagramId, diagramDefinition));
+        if (token !== this.renderToken) {
+          return;
+        }
+        this.diagramRef.innerHTML = rendered.svg;
+        if (rendered.bindFunctions) {
+          rendered.bindFunctions(this.diagramRef);
         }
         updateDiagramStyle(this.diagramRef, this.props.data, this.props.options, diagramId);
       } catch (err) {
@@ -202,6 +190,7 @@ export class DiagramPanelController extends React.Component<DiagramPanelControll
   };
 
   getLegendItems = () => {
+    const { stats } = this.props.options.legend;
     return this.props.data.reduce<VizLegendItem[]>((acc, s) => {
       return this.shouldHideLegendItem(s.data, this.props.options.legend.hideEmpty, this.props.options.legend.hideZero)
         ? acc
@@ -212,7 +201,8 @@ export class DiagramPanelController extends React.Component<DiagramPanelControll
               disabled: !s.isVisible,
               yAxis: 0,
               getDisplayValues: () => {
-                return s.info || [];
+                const info = s.info || [];
+                return stats && stats.length > 0 ? info.filter((dv) => stats.includes(dv.title as string)) : info;
               },
             },
           ]);
@@ -220,14 +210,15 @@ export class DiagramPanelController extends React.Component<DiagramPanelControll
   };
 
   render() {
+    const { diagramContainer, wrapper, legendContainer } = getDiagramWithLegendStyles(this.props);
     return (
-      <div className={`diagram-container diagram-container-${this.props.id}` && this.state.wrapper}>
+      <div className={cx('diagram-container', `diagram-container-${this.props.id}`, wrapper)}>
         <div
           ref={this.setDiagramRef}
-          className={`diagram diagram-${this.props.id}` && this.state.diagramContainer}
+          className={cx('diagram', `diagram-${this.props.id}`, diagramContainer)}
         ></div>
         {this.props.options.legend.show && (
-          <div className={this.state.legendContainer}>
+          <div className={legendContainer}>
             <CustomScrollbar hideHorizontalTrack>
               <DiagramErrorBoundary fallback="Error rendering Legend">
                 <VizLegend

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import { FieldConfigProperty, PanelOptionsEditorBuilder, PanelPlugin, SelectableValue } from '@grafana/data';
+import { LegendDisplayMode } from '@grafana/ui';
 import { defaults } from './config/diagramDefaults';
 import { diagramPanelChangeHandler } from './config/diagramPanelChangeHandler';
 import { CompositeMetricEditor } from './editors/CompositeMetricEditor';
@@ -216,6 +217,46 @@ const createPanelPlugin = () => {
           description: 'Show the legend',
           category: ['Legend'],
           defaultValue: defaults.legend.show,
+        })
+        .addRadio({
+          name: 'Legend placement',
+          path: 'legend.placement',
+          description: 'Where to place the legend relative to the diagram',
+          category: ['Legend'],
+          defaultValue: defaults.legend.placement,
+          settings: {
+            options: [
+              { value: 'bottom', label: 'Bottom' },
+              { value: 'right', label: 'Right' },
+            ],
+          },
+          showIf: (currentOptions) => currentOptions.legend.show,
+        })
+        .addRadio({
+          name: 'Legend mode',
+          path: 'legend.displayMode',
+          description: 'Table shows a sortable header row with values; list shows names only',
+          category: ['Legend'],
+          defaultValue: defaults.legend.displayMode,
+          settings: {
+            options: [
+              { value: LegendDisplayMode.Table, label: 'Table' },
+              { value: LegendDisplayMode.List, label: 'List' },
+            ],
+          },
+          showIf: (currentOptions) => currentOptions.legend.show,
+        })
+        .addMultiSelect<string, any>({
+          name: 'Legend values',
+          path: 'legend.stats',
+          description: 'Which reductions to show as legend table columns',
+          category: ['Legend'],
+          defaultValue: defaults.legend.stats as any,
+          settings: {
+            options: statSelectOptions,
+          },
+          showIf: (currentOptions) =>
+            currentOptions.legend.show && currentOptions.legend.displayMode === LegendDisplayMode.Table,
         })
         // Composites
         .addCustomEditor({

--- a/src/visualizers/updateDiagramStyle.test.ts
+++ b/src/visualizers/updateDiagramStyle.test.ts
@@ -1,0 +1,78 @@
+import { updateDiagramStyle } from './updateDiagramStyle';
+import { DiagramOptions, DiagramSeriesModel } from '../config/types';
+
+const makeModel = (label: string, value: number, color?: string): DiagramSeriesModel =>
+  ({
+    label,
+    data: [[0, value]],
+    isVisible: true,
+    seriesIndex: 0,
+    timeStep: 1,
+    timeField: {} as any,
+    valueField: { config: { custom: { valueName: 'last' } } } as any,
+    info: [{ title: 'last', numeric: value, text: String(value), color } as any],
+  } as DiagramSeriesModel);
+
+const baseOptions = (overrides: Partial<DiagramOptions> = {}): DiagramOptions =>
+  ({
+    useBackground: false,
+    nodeSize: { minWidth: 30, minHeight: 30 },
+    composites: [],
+    style: '',
+    maxWidth: true,
+    ...overrides,
+  } as unknown as DiagramOptions);
+
+const container = (svgInner: string): HTMLElement => {
+  const el = document.createElement('div');
+  el.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg">${svgInner}</svg>`;
+  return el;
+};
+
+describe('updateDiagramStyle', () => {
+  describe('flowchart binding (regression guard)', () => {
+    it('injects a .diagram-value onto a node matched by data-id', () => {
+      const el = container('<g data-id="Orders"><foreignObject><div>Orders</div></foreignObject></g>');
+      updateDiagramStyle(el, [makeModel('Orders', 120)], baseOptions(), 'd1');
+      expect(el.querySelector('.diagram-value')).not.toBeNull();
+      expect(el.innerHTML).toContain('120');
+    });
+  });
+
+  describe('sequence binding (exact match)', () => {
+    it('binds the value onto an actor on its own line, without throwing', () => {
+      const el = container('<text class="actor"><tspan x="10">Orders</tspan></text>');
+      expect(() => updateDiagramStyle(el, [makeModel('Orders', 120)], baseOptions(), 'd2')).not.toThrow();
+      const value = el.querySelector('tspan.diagram-value');
+      expect(value?.textContent).toBe('120');
+      expect(value?.getAttribute('dy')).toBe('1.2em');
+    });
+
+    it('colors the whole actor label (name + value) like a graph node', () => {
+      const el = container('<text class="actor"><tspan x="10">Orders</tspan></text>');
+      updateDiagramStyle(el, [makeModel('Orders', 120, 'rgb(255, 0, 0)')], baseOptions(), 'd3');
+      expect(el.querySelector('text.actor')?.getAttribute('style')).toContain('rgb(255, 0, 0)');
+    });
+
+    it('binds onto a message (connection) label, coloring only the value', () => {
+      const el = container('<text class="messageText">charge</text>');
+      updateDiagramStyle(el, [makeModel('charge', 42, 'rgb(0, 0, 255)')], baseOptions(), 'd4');
+      const value = el.querySelector('tspan.diagram-value');
+      expect(value?.textContent).toBe('42');
+      expect(value?.getAttribute('style')).toContain('rgb(0, 0, 255)');
+      expect(el.querySelector('text.messageText')?.getAttribute('style') || '').not.toContain('rgb(0, 0, 255)');
+    });
+
+    it('does not bind when the name matches no element', () => {
+      const el = container('<text>Other</text>');
+      updateDiagramStyle(el, [makeModel('Orders', 120)], baseOptions(), 'd5');
+      expect(el.querySelector('.diagram-value')).toBeNull();
+    });
+
+    it('does NOT bind on a partial/substring match (exact only)', () => {
+      const el = container('<text>Orders total</text>');
+      updateDiagramStyle(el, [makeModel('Orders', 120)], baseOptions(), 'd6');
+      expect(el.querySelector('.diagram-value')).toBeNull();
+    });
+  });
+});

--- a/src/visualizers/updateDiagramStyle.test.ts
+++ b/src/visualizers/updateDiagramStyle.test.ts
@@ -37,6 +37,28 @@ describe('updateDiagramStyle', () => {
       expect(el.querySelector('.diagram-value')).not.toBeNull();
       expect(el.innerHTML).toContain('120');
     });
+
+    it('colors the whole flowchart edge label (label + value), not just the value', () => {
+      const el = container(
+        '<g class="edgeLabels"><g class="edgeLabel"><foreignObject><div class="labelBkg"><span class="edgeLabel">charge</span></div></foreignObject></g></g>'
+      );
+      updateDiagramStyle(el, [makeModel('charge', 42, 'rgb(1, 2, 3)')], baseOptions(), 'dA');
+      const label = el.querySelector('span.edgeLabel');
+      const value = el.querySelector('.diagram-value');
+      expect(value?.getAttribute('style') || '').toContain('color: rgb(1, 2, 3)');
+      expect(label?.getAttribute('style') || '').toContain('color: rgb(1, 2, 3)');
+    });
+
+    it('colors the edge label background too in background mode', () => {
+      const el = container(
+        '<g class="edgeLabels"><g class="edgeLabel"><foreignObject><div class="labelBkg"><span class="edgeLabel">charge</span></div></foreignObject></g></g>'
+      );
+      updateDiagramStyle(el, [makeModel('charge', 42, 'rgb(9, 8, 7)')], baseOptions({ useBackground: true }), 'dB');
+      const label = el.querySelector('span.edgeLabel');
+      const value = el.querySelector('.diagram-value');
+      expect(value?.getAttribute('style') || '').toContain('background-color: rgb(9, 8, 7)');
+      expect(label?.getAttribute('style') || '').toContain('background-color: rgb(9, 8, 7)');
+    });
   });
 
   describe('sequence binding (exact match)', () => {
@@ -54,13 +76,13 @@ describe('updateDiagramStyle', () => {
       expect(el.querySelector('text.actor')?.getAttribute('style')).toContain('rgb(255, 0, 0)');
     });
 
-    it('binds onto a message (connection) label, coloring only the value', () => {
+    it('colors the whole message label (name + value) like a graph node', () => {
       const el = container('<text class="messageText">charge</text>');
       updateDiagramStyle(el, [makeModel('charge', 42, 'rgb(0, 0, 255)')], baseOptions(), 'd4');
       const value = el.querySelector('tspan.diagram-value');
       expect(value?.textContent).toBe('42');
       expect(value?.getAttribute('style')).toContain('rgb(0, 0, 255)');
-      expect(el.querySelector('text.messageText')?.getAttribute('style') || '').not.toContain('rgb(0, 0, 255)');
+      expect(el.querySelector('text.messageText')?.getAttribute('style') || '').toContain('rgb(0, 0, 255)');
     });
 
     it('does not bind when the name matches no element', () => {

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -47,14 +47,6 @@ const selectTextElementByAlias = (container: HTMLElement, alias: string): Select
     });
 };
 
-const selectTextElementContainingAlias = (container: HTMLElement, alias: string): Selection<any, any, any, any> => {
-  return select(container)
-    .selectAll('text')
-    .filter(function () {
-      return select(this).text().includes(alias);
-    });
-};
-
 const fetchParentsUntilShapeElementFound = (element: HTMLElement, selector: string): HTMLElement | null => {  
   if (element.matches(selector)) {
     return element;
@@ -141,61 +133,30 @@ const styleFlowChartEdgeLabel = (
   }
 };
 
-const styleTextEdgeLabel = (
-  targetElement: Selection<any, any, any, any>,
-  indicator: MetricIndicator,
-  useBackground: boolean
-) => {
-  targetElement.each((el) => {
-    let markerBox = {
-      x: el.getBBox().x,
-      y: el.getBBox().y + el.getBBox().height + 10,
-      width: el.getBBox().width,
-      height: el.getBBox().height,
-    };
+const styleSequenceText = (targetElement: Selection<any, any, any, any>, indicator: MetricIndicator) => {
+  targetElement.each(function (this: SVGTextElement) {
+    const textNode = this;
+    const isActor = (textNode.getAttribute('class') || '').includes('actor');
+    const anchorX = textNode.querySelector('tspan')?.getAttribute('x') ?? textNode.getAttribute('x');
+    const y = Number.parseFloat(textNode.getAttribute('y') || '');
+    if (!Number.isNaN(y)) {
+      textNode.setAttribute('y', String(y + (isActor ? -9 : 8)));
+    }
+    const value = select(textNode)
+      .append('tspan')
+      .classed('diagram-value', true)
+      .attr('x', anchorX)
+      .attr('dy', isActor ? '1.2em' : '1.5em')
+      .text(formattedValueToString(indicator));
     if (indicator.color) {
-      const rect = select(el.parentNode)
-        .insert('rect')
-        .attr('x', markerBox.x)
-        .attr('y', markerBox.y)
-        .attr('width', markerBox.width)
-        .attr('height', markerBox.height);
-      const textNode = select(el.parentNode)
-        .insert('text')
-        .text(formattedValueToString(indicator))
-        .attr('x', markerBox.x + markerBox.width / 2)
-        .attr('y', markerBox.y + markerBox.height - 1)
-        .attr('width', markerBox.width)
-        .attr('height', markerBox.height)
-        .style('text-anchor', 'middle');
-      if (indicator.color) {
-        if (useBackground) {
-          rect.style('fill', indicator.color);
-        } else {
-          textNode.style('color', indicator.color);
-        }
+      if (isActor) {
+        select(textNode).style('fill', indicator.color).selectAll('tspan').style('fill', indicator.color);
+      } else {
+        value.style('fill', indicator.color);
       }
     }
   });
 };
-
-const styleSequenceDiagramEdgeLabel = (
-  targetElement: Selection<any, any, any, any>,
-  indicator: MetricIndicator,
-  useBackground: boolean,
-  nodeSize: NodeSizeOptions
-) => {
-  const spanElement = targetElement.append('tspan');
-  spanElement.classed('diagram-value', true);
-  spanElement.html(formattedValueToString(indicator));
-  if (indicator.color) {
-    if (useBackground) {
-      spanElement.style('background-color', indicator.color);
-    } else {
-      spanElement.style('color', indicator.color);
-    }
-  }
-}
 
 const injectCustomStyle = (container: HTMLElement, diagramStyle: string, diagramId: string) => {
   const diagramDiv = select(container);
@@ -227,13 +188,7 @@ const processDiagramSeriesModel = (container: HTMLElement, indicator: MetricIndi
 
   targetElement = selectTextElementByAlias(container, key);
   if (!targetElement.empty()) {
-    styleTextEdgeLabel(targetElement, indicator, options.useBackground);
-    return;
-  }
-
-  targetElement = selectTextElementContainingAlias(container, key);
-  if (!targetElement.empty()) {
-    styleSequenceDiagramEdgeLabel(targetElement, indicator, options.useBackground, options.nodeSize);
+    styleSequenceText(targetElement, indicator);
     return;
   }
 

--- a/src/visualizers/updateDiagramStyle.ts
+++ b/src/visualizers/updateDiagramStyle.ts
@@ -125,10 +125,14 @@ const styleFlowChartEdgeLabel = (
   if (indicator.color) {
     if (useBackground) {
       v.style('background-color', indicator.color);
+      // Color the edge label too, so the whole connection matches (nodes color name+value together).
+      targetElement.style('background-color', indicator.color);
       const parentShapeElement = fetchParentsUntilShapeElementFound(targetElement.node(), '.node.flowchart-label');
       parentShapeElement?.firstElementChild?.setAttribute('style', `fill: ${indicator.color}`);
     } else {
       v.style('color', indicator.color);
+      // Color the edge label too, not just the appended value.
+      targetElement.style('color', indicator.color);
     }
   }
 };
@@ -142,18 +146,16 @@ const styleSequenceText = (targetElement: Selection<any, any, any, any>, indicat
     if (!Number.isNaN(y)) {
       textNode.setAttribute('y', String(y + (isActor ? -9 : 8)));
     }
-    const value = select(textNode)
+    select(textNode)
       .append('tspan')
       .classed('diagram-value', true)
       .attr('x', anchorX)
       .attr('dy', isActor ? '1.2em' : '1.5em')
       .text(formattedValueToString(indicator));
     if (indicator.color) {
-      if (isActor) {
-        select(textNode).style('fill', indicator.color).selectAll('tspan').style('fill', indicator.color);
-      } else {
-        value.style('fill', indicator.color);
-      }
+      // Color the whole text (message/actor label) and its value tspan, so a connection
+      // (message) matches how an actor/node colors its name+value together.
+      select(textNode).style('fill', indicator.color).selectAll('tspan').style('fill', indicator.color);
     }
   });
 };


### PR DESCRIPTION
## Summary
Grafana data did not bind onto sequence diagrams: matching a series to an actor/message crashed the panel with `TypeError: Cannot read properties of undefined (reading 'getBBox')`, so the diagram was replaced by an error — while the same data bound fine onto flowchart diagrams. This PR fixes the binding, styles sequence values to match flowcharts — colouring the whole label (name+value) on both shapes and connections — makes text matching exact, re-exposes the legend placement/mode/value controls, and hardens rendering against concurrent renders. It also fixes the **table-legend header row** disappearing on newer Grafana (13.x). Related: #239.

## Root cause
`styleTextEdgeLabel` (`src/visualizers/updateDiagramStyle.ts`) iterated matched `<text>` nodes with `.each((el) => el.getBBox())`. In d3 the arrow callback's first argument is the datum (undefined for mermaid's text nodes), not the DOM node, so `getBBox()` threw. It also gated value insertion behind a resolved threshold color.

Separately, newer Grafana's `VizLegend`/`VizLegendTable` marks every table-legend header cell `sr-only` (visually hidden) unless the legend is flagged `isSortable`; the plugin never set it, so the column-name header row disappeared on Grafana 13.1.0 (it rendered unconditionally on 12.3.1).

## Changes
- **Binding fix**: iterate DOM nodes correctly; always insert the value as a `.diagram-value` `<tspan>`. Values are styled like flowchart nodes — the whole label is threshold-coloured (name **and** value together): an actor centres the value below its name, while a message/connection keeps its label above the line with the value below it. Actors **and** messages/edges now bind data.
- **Connection label colour**: flowchart **edge** labels and sequence **message** labels take the threshold colour across the whole label, not just the appended value — previously the label kept the default colour while only the value was coloured, inconsistent with nodes/actors. Both text-colour and background modes covered, with unit tests.
- **Exact matching only**; the substring matcher is removed (it over-matched, e.g. `Orders` also hit `Orders total`). ⚠️ Behaviour change: dashboards relying on substring matching must use exact series names.
- **Legend**: panel-editor controls for Placement (Bottom/Right), Mode (Table/List) and Values; placement applies live.
- **Legend header on Grafana 13**: the table-legend now sets `isSortable` so Grafana's `VizLegend` renders the header row (column names) again; sorting was already wired via `onToggleSort`. The prop postdates the pinned `@grafana/ui@9.0.9` build-time types but is honored by the host Grafana at runtime, so it is added with a `@ts-expect-error`.
- **Concurrent-render safety**: `initializeMermaid` runs on mount and on data updates; two overlapping runs shared one mermaid id and could corrupt the diagram / misbind values. Each render now uses a unique id and only the latest render is applied.
- **Tests**: unit tests for the binding/styling logic (`updateDiagramStyle.test.ts`), including the connection-label colouring; jest maps `d3` to its UMD bundle so the ESM package loads under the scaffold config.

## Verification
`yarn typecheck && yarn lint && yarn test:ci && yarn build` all pass. Verified live in **Grafana 12.3.1 and 13.1.0**: the same TestData series (Orders/Payments/Shipping + charge/fulfil) bind onto both a flowchart and a sequence diagram — on nodes/actors and edges/messages — with the threshold colour applied to the whole label (name+value) on shapes **and** connections, and no error; the table-legend header row (Name + stat columns) renders on both (it was hidden on 13.1.0 before this fix). Scoped to the pinned mermaid 10.8.0.
